### PR TITLE
Support new compact format in `package.json`

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,17 @@ function read(package_path) {
 }
 
 function extract(pkg) {
-  var watches = pkg.watches;
+  var watches;
+  if (Array.isArray(pkg.watches)) {
+    watches = pkg.watches;
+  } else {
+    watches = Object.keys(pkg.watches).map(function (key) {
+      return {
+        "script": key,
+        "patterns": pkg.watches[key]
+      };
+    });
+  }
   debug('watches list: %s', JSON.stringify(watches));
   return watches;
 }

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 [![Build Status](http://img.shields.io/travis/wilmoore/rerun-script.svg)](https://travis-ci.org/wilmoore/rerun-script) [![NPM version](http://img.shields.io/npm/v/rerun-script.svg)](https://www.npmjs.org/package/rerun-script) [![NPM downloads](http://img.shields.io/npm/dm/rerun-script.svg)](https://www.npmjs.org/package/rerun-script) [![LICENSE](http://img.shields.io/npm/l/rerun-script.svg)](license)
 
-> Invoke npm scripts upon file changes. Configure via package.json using glob patterns.
+> Invoke npm scripts upon file changes. Configure via `package.json` using glob patterns.
 
     $ npm install rerun-script --save-dev
 
@@ -39,6 +39,21 @@
                 "patterns": [ "*.js", "lib/**/*.js", "test/**/*.js" ]
             }
         ]
+    }
+
+You can also use a more compact format for watches:
+
+    {
+        "scripts": {
+            "test": "node test.js",
+            "lint": "eslint",
+            "watch": "rerun-script"
+        },
+
+        "watches": {
+            "test": [ "*.js", "lib/**/*.js", "test/**/*.js" ],
+            "lint": [ "*.js", "lib/**/*.js", "test/**/*.js" ]
+        }
     }
 
 ## screenshot


### PR DESCRIPTION
Instead of defining watches in `package.json` as an array, each with a `script` and `patterns` key, this enables you to define watches as an object in the following format:

```
"watches": {
  <npm test>: [<patterns>]
}
```

This pr is backwards compatible so it doesn't break existing projects, and you can still use the more expanded syntax.
Regardless of which style you use, the `getDefaults` function maintains the same interface, so the tests still pass as well.
