### PR TITLE
If `patterns` is a string, convert to an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,12 @@ function extract (pkg) {
       }
     })
   }
+  watches = watches.map(function (watch) {
+    if (!Array.isArray(watch.patterns)) {
+      watch.patterns = [watch.patterns]
+    }
+    return watch
+  })
   debug('watches list: %s', JSON.stringify(watches))
   return watches
 }

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,22 @@
         ]
     }
 
+If you only have one pattern to match for a script, you can pass in a string instead of an array:
+
+
+    {
+        "scripts": {
+            "test": "node test.js",
+            "lint": "standard",
+            "watch": "rerun-script"
+        },
+
+        "watches": {
+            "test": "test/**/*.js",
+            "lint": "*.js"
+        }
+    }
+
 ## start the watcher
 
     # directly


### PR DESCRIPTION
If you only have one pattern you are interested in watching, you can now pass a string instead of an array and `extract` will simply convert it to an array with a single item. 

For example:

```
    {
        "scripts": {
            "test": "node test.js",
            "lint": "standard",
            "watch": "rerun-script"
        },

        "watches": {
            "test": "test/**/*.js",
            "lint": "*.js"
        }
    }
```

Again, this pull request leaves the interface the same, so all tests pass. It simply catches the string and wraps it in an array instead of throwing an error.
